### PR TITLE
[surfman] Xenstore check hang

### DIFF
--- a/surfman/src/rpc.c
+++ b/surfman/src/rpc.c
@@ -88,18 +88,6 @@ rpc_disconnect (dmbus_client_t client, void *priv)
   struct domain *d;
 
   surfman_info ("DM disconnected. domid %d", dev->d->domid);
-  for (;;) {
-    unsigned int num;
-    char **x = xenstore_ls(&num, "/local/domain/%d", dev->d->domid);
-    if (!x) {
-      surfman_info ("Domain gone %d, proceeding", dev->d->domid);
-      break;
-    }
-    free(x);
-    usleep(1000 * 100);
-  }
-  surfman_info ("DM disconnected - detected domain gone, proceeding");
-
   event_del (&dev->ev);
 
   if (dev->ops && dev->ops->takedown)


### PR DESCRIPTION
That loop goes 'infinite' for XenFB devices if say dm-agent is restarted.
Also it is aimed to check that the domain info have disapeared from
Xenstore in case there is a GPU to FLR. This test seems to be done in
vgpu.c already (and should be done in the takedown callback anyway for
that specific purpose).
