### PR TITLE
Use udev monitor instead of udev enum to ensure we find the i915 DRM …

### DIFF
--- a/plugins/drm/src/udev.c
+++ b/plugins/drm/src/udev.c
@@ -30,36 +30,40 @@ static inline struct udev_device *udev_device_new_from_list_entry(struct udev *u
 INTERNAL int udev_process_subsystem(struct udev *udev, const char *subsystem,
                                     void *(*action)(struct udev *, struct udev_device *))
 {
-    struct udev_enumerate *e;
-    struct udev_list_entry *devs, *deve;
     int rc;
+    fd_set readfds;
+    int udevfd;
+    struct udev_monitor *udev_mon;
+    struct udev_device *udev_dev;
 
-    e = udev_enumerate_new(udev);
-    if (!e) {
-        rc = -errno;
-        DRM_DBG("udev_enumerate_new failed (%s).", strerror(-rc));
-        return rc;
-    }
-    udev_enumerate_add_match_is_initialized(e);
-    udev_enumerate_add_match_subsystem(e, subsystem);
+    udev_mon = udev_monitor_new_from_netlink(udev, "udev");
+    udev_monitor_filter_add_match_subsystem_devtype(udev_mon, subsystem, NULL);
+    udev_monitor_enable_receiving(udev_mon);
+    udevfd = udev_monitor_get_fd(udev_mon);
 
-    udev_enumerate_scan_devices(e);
-    devs = udev_enumerate_get_list_entry(e);
-    if (!devs) {
-        rc = -errno;
-        DRM_DBG("udev_enumerate_get_list_entry failed (%s).", strerror(-rc));
-        udev_enumerate_unref(e);
-        return rc;
-    }
-    udev_list_entry_foreach(deve, devs) {
-        struct udev_device *d;
+    do {
+        FD_ZERO(&readfds);
+        FD_SET(udevfd, &readfds);
 
-        d = udev_device_new_from_list_entry(udev, deve);
-        action(udev, d);
-        udev_device_unref(d);
-    }
-    udev_enumerate_unref(e);
-    return 0;
+        rc = select(udevfd + 1, &readfds, NULL, NULL, NULL);
+        if (rc > 0 && FD_ISSET(udevfd, &readfds)) {
+            udev_dev = udev_monitor_receive_device(udev_mon);
+            if (!udev_dev) {
+                DRM_DBG("No device in monitor callback?");
+                continue;
+            }
+
+            if (action(udev, udev_dev) != NULL) {
+                DRM_DBG("Found device, leaving monitor.");
+                udev_device_unref(udev_dev);
+                break;
+            }
+            udev_device_unref(udev_dev);
+        }
+    } while (1);
+
+    udev_monitor_unref(udev_mon);
+    return rc;
 }
 
 /*


### PR DESCRIPTION
…device.

OXT-634

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>