### PR TITLE
Round down resolutions that are not divisible by 8.

### DIFF
--- a/surfman/src/ioemugfx.c
+++ b/surfman/src/ioemugfx.c
@@ -103,6 +103,7 @@ ioemugfx_display_get_info(void *priv,
   struct ioemugfx_device *dev = priv;
   struct monitor *m;
   int align;
+  uint16_t rounded_xres;
 
   surfman_info ("DisplayID:%d", msg->DisplayID);
 
@@ -117,7 +118,17 @@ ioemugfx_display_get_info(void *priv,
   out->max_xres = m->info->i.prefered_mode->htimings[0];
   out->max_yres = m->info->i.prefered_mode->vtimings[0];
 
-  surfman_info ("Monitor %d: Max resolution: %dx%d, stride alignment:%d",
+  /* Checking for resolutions that are not divisible by 8 and rounding them
+   * down. See the comment in plugins/drm/src/device-intel.c!should_avoid_scaling()
+   */
+  rounded_xres = out->max_xres & ~0x7;
+  if (rounded_xres != out->max_xres) {
+    surfman_info ("Monitor %d: Rounding down xres: %d -> %d",
+        msg->DisplayID, out->max_xres, rounded_xres);
+    out->max_xres = rounded_xres;
+  }
+
+  surfman_info ("Monitor %d: Max resolution: %dx%d, stride alignment: %d",
         msg->DisplayID, out->max_xres, out->max_yres, out->align);
 
   return 0;


### PR DESCRIPTION
This is really a quirk following the logic in surfman PR #4 that does the same
checking. This change allows the "rounded down" xres to be reported to the
guest via the EDID as well as in the Vesa modes table (where e.g. 1366x768 was
changed to 1360x768). The value in the EDID is being used and set by XenVesaDO
when it first starts causing modeset failures when not rounded down.

OXT-640

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>