### PR TITLE
Fix libxc call

### DIFF
--- a/surfman/src/domain.c
+++ b/surfman/src/domain.c
@@ -35,7 +35,7 @@ domain_dying (struct domain *d)
 {
   xc_dominfo_t info;
 
-  if (xc_domid_getinfo (d->domid, &info))
+  if (!xc_domid_getinfo (d->domid, &info))
     return 0;
   return info.dying;
 }


### PR DESCRIPTION
xc_domid_getinfo() returns xc_domain_getinfo() which returns the number of domains found.
0 means not found, which is when `info` is undefined.

Signed-off-by: Jed <lejosnej@ainfosec.com>