### PR TITLE
STABLE-6: OXT-1108: surfman: Load plugins for non-primary devices.

### DIFF
--- a/surfman/src/plugin.c
+++ b/surfman/src/plugin.c
@@ -167,15 +167,6 @@ pci_vendor_match (const char *vendors)
       while ((device = pci_device_next(iter)))
         {
           pci_device_probe(device);
-          /* !! THE BLOC BELOW IS A NASTY HACK !! */
-          /* !! REMOVE IT WHEN AMD FIX THEIR PLUGIN !! */
-          if (!pci_device_is_boot_vga(device))
-            {
-              surfman_info("  - NOT using %04x:%04x at %02x:%02x.%02x, as it is NOT the primary adapter",
-                  device->vendor_id, device->device_id,
-                  device->bus, device->dev, device->func);
-              continue;
-            }
           surfman_info ("  - found %04x:%04x at %02x:%02x.%02x",
                   device->vendor_id, device->device_id,
                   device->bus, device->dev, device->func);


### PR DESCRIPTION
There is no guaranty on what device will be PCI_CLASS 0x300 or 0x380,
but the plugin should be loaded for this one anyway (plus restricting
to primary display was a hack for a defunct plugin).

It turns out to usually be the integrated one, also most firmware allows
that to be configured, but some platforms (e.g, HP 800 G1) will
__change__ the PCI class of the Intel device when a PCI(e) discrete card
is racked (0x300->0x380). Whatever happens next is unwanted.

OXT-1108