### PR TITLE
[Xen 4.9] privcmd.h now requires size_t to be defined

### DIFF
--- a/libsurfman/configure.ac
+++ b/libsurfman/configure.ac
@@ -69,6 +69,7 @@ AC_CHECK_HEADERS([xen/hvm/ioreq.h], [], AC_MSG_ERROR([ioreq header is missing.])
 AC_CHECK_HEADERS([xen/xen.h], [], AC_MSG_ERROR([xen header is missing.]))
 AC_CHECK_HEADERS([xen/sys/privcmd.h], [], AC_MSG_ERROR([privcmd header is missing.]), [
                   #include <stdint.h>
+                  #include <stddef.h>
                   #include <linux/ioctl.h>
                   #include <xen/xen.h>
                   ])

--- a/libsurfman/src/project.h
+++ b/libsurfman/src/project.h
@@ -23,6 +23,7 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <stdint.h>
+# include <stddef.h>
 # include <stdarg.h>
 # include <ctype.h>
 


### PR DESCRIPTION
OXT-1203 for Xen upgrade.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>