### PR TITLE
OXT-1622: surfman: xc_domain_getinfo usage.

### DIFF
--- a/libsurfman/src/xc.c
+++ b/libsurfman/src/xc.c
@@ -37,18 +37,21 @@ void xc_init (void)
     }
 }
 
-int xc_domid_exists (int domid)
-{
-  xc_dominfo_t info;
-  int rc;
-
-  rc = xc_domain_getinfo (xch, domid, 1, &info);
-  return rc >= 0 ? info.domid == (domid_t)domid : 0;
-}
-
 int xc_domid_getinfo(int domid, xc_dominfo_t *info)
 {
-  return xc_domain_getinfo (xch, domid, 1, info);
+  int rc;
+
+  rc = xc_domain_getinfo (xch, domid, 1, info);
+  if (rc == 1)
+    return info->domid == (domid_t)domid ? 1 : -ENOENT;
+  return rc;
+}
+
+int xc_domid_exists(int domid)
+{
+  xc_dominfo_t info = { 0 };
+
+  return !!xc_domid_getinfo(domid, &info);
 }
 
 void *xc_mmap_foreign(void *addr, size_t length, int prot,

--- a/surfman/src/domain.c
+++ b/surfman/src/domain.c
@@ -35,7 +35,7 @@ domain_dying (struct domain *d)
 {
   xc_dominfo_t info;
 
-  if (!xc_domid_getinfo (d->domid, &info))
+  if (xc_domid_getinfo (d->domid, &info) != 1)
     return 0;
   return info.dying;
 }


### PR DESCRIPTION
xc_domain_getinfo(h, domid, n, info):
will return the number of xc_dominfo_t written in info and fill
info starting with the first domain with domain_id >= domid.

In practice, this means, xc_domain_getinfo(h, domid, 1, info), may fill
the info struct for a domain which domain_id != domid. This is a problem
for xc_domid_exists() which makes that assumption.

Since libsurfman provides xc_domid_getinfo() handle the case in it and
use the exported function across surfman.

The main in this is xc_domid_getinfo() will return -ENOENT if the domain
associated with the domid in argument does not exist.
