### PR TITLE
OXT-1653: Attend crashes related to external display handling.

### DIFF
--- a/plugins/drm/src/Makefile.am
+++ b/plugins/drm/src/Makefile.am
@@ -28,12 +28,12 @@ SRCS =	drm-plugin.c			\
 	hotplug.c			\
 	backlight.c
 
-noinst_HEADERS = drm-plugin.h utils.h list.h project.h prototypes.h
+HDRS = drm-plugin.h utils.h list.h project.h prototypes.h
 
 plugindir = ${libdir}/surfman
 plugin_LTLIBRARIES = drm-plugin.la
 
-drm_plugin_la_SOURCES = ${SRCS}
+drm_plugin_la_SOURCES = ${SRCS} ${HDRS}
 drm_plugin_la_LDFLAGS = -module
 drm_plugin_la_CFLAGS = ${LIBUDEV_CFLAGS} ${LIBDRM_CFLAGS} ${LIBSURFMAN_CFLAGS} -W -Wall -Werror -g
 drm_plugin_la_CPPFLAGS = ${LIBUDEV_CFLAGS} ${LIBDRM_CFLAGS} ${LIBSURFMAN_CFLAGS}

--- a/plugins/drm/src/device.c
+++ b/plugins/drm/src/device.c
@@ -190,6 +190,8 @@ INTERNAL struct drm_plane *drm_device_add_plane(struct drm_device *device, uint3
     p = drm_device_find_plane(device, plane);
     if (!p) {
         p = calloc(1, sizeof (*p));
+        if (!p)
+            return NULL;
         p->id = plane;
         p->device = device;
         list_add_tail(&p->l, &device->planes);

--- a/plugins/drm/src/drm-plugin.c
+++ b/plugins/drm/src/drm-plugin.c
@@ -191,9 +191,17 @@ INTERNAL int drmp_get_monitors(surfman_plugin_t *plugin, surfman_monitor_t *moni
     (void) plugin;
     struct drm_device *d, *dd;
     unsigned int j = 0;
+    int rc;
 
     list_for_each_entry_safe(d, dd, &devices, l) {
         struct drm_monitor *m, *mm;
+
+        rc = drm_monitors_scan(d);
+        if (rc < 0) {
+            DRM_WRN("Failed to scan for monitors on device %s (%s).",
+                    d->devnode, strerror(-rc));
+            continue;
+        }
 
         DRM_DBG("Device %s monitors:", d->devnode);
         list_for_each_entry_safe(m, mm, &(d->monitors), l_dev) {

--- a/plugins/drm/src/hotplug.c
+++ b/plugins/drm/src/hotplug.c
@@ -25,33 +25,26 @@ static void hotplug_event_handler(int fd, short event, void *priv)
 {
     struct hotplug *hotplug = priv;
     struct udev_device *dev;
-    struct drm_device *d, *dd;
     const char *devnode;
 
     (void) fd;
     (void) event;
+
+    /* Notify surfman to rescan monitors.
+     * This will trigger a callback to the plugin on Surfman's terms. */
+    surfman_plugin.notify |= SURFMAN_NOTIFY_MONITOR_RESCAN;
+
     dev = udev_monitor_receive_device(hotplug->monitor);
     if (!dev) {
         DRM_WRN("Could not recover the device which triggered this udev event (%s).",
                 strerror(errno));
         return;
     }
+
     devnode = udev_device_get_devnode(dev);
     DRM_DBG("%s: %s (%s) triggred `%s' event.", udev_device_get_subsystem(dev),
             udev_device_get_sysname(dev), devnode, udev_device_get_action(dev));
-
-    /* TODO: Who knows... some cardX might appear, but we'll see that later. */
-    if (devnode) {
-        /* TODO: Those lists will require some sync mecanisms someday... */
-        list_for_each_entry_safe(d, dd, &devices, l) {
-            if (!strcmp(d->devnode, devnode)) {
-                drm_monitors_scan(d);
-                break;
-            }
-        }
-    }
     udev_device_unref(dev);
-    surfman_plugin.notify |= SURFMAN_NOTIFY_MONITOR_RESCAN;
     return;
 }
 

--- a/surfman/src/display.c
+++ b/surfman/src/display.c
@@ -269,6 +269,11 @@ display_update_monitors (struct plugin *p,
     {
       struct monitor_info *info = get_monitor_info (p, monitors[i]);
 
+      /* The plugin does not recognize the monitor, or it was yanked quickly
+       * after being plugged. */
+      if (info == NULL)
+        continue;
+
       for (j = 0; j < DISPLAY_MONITOR_MAX; j++)
         {
           if (display[j].plugin == p &&


### PR DESCRIPTION
Attend a couple of crashes related to external displays:
- libdrm release the mode list when the screen is unplugged.
- Upscaling cannot go beyond display biggest resolution.
- Error path should never assume a plugin function will succeed.
- Same for calloc.

Amend the automake definition to include header dependencies.