### PR TITLE
S9: OXT-1650: Support vfb from HVM or PVH guests.

### DIFF
--- a/libsurfman/src/project.h
+++ b/libsurfman/src/project.h
@@ -50,6 +50,7 @@
 # include <sys/types.h>
 # include <sys/ioctl.h>
 
+# define XC_WANT_COMPAT_MAP_FOREIGN_API
 # include <xenctrl.h>
 # include <xen/sys/privcmd.h>
 # include <xen/hvm/ioreq.h>

--- a/libsurfman/src/project.h
+++ b/libsurfman/src/project.h
@@ -51,6 +51,7 @@
 # include <sys/ioctl.h>
 
 # define XC_WANT_COMPAT_MAP_FOREIGN_API
+# define XC_WANT_COMPAT_DEVICEMODEL_API
 # include <xenctrl.h>
 # include <xen/sys/privcmd.h>
 # include <xen/hvm/ioreq.h>

--- a/libsurfman/src/surfman.h
+++ b/libsurfman/src/surfman.h
@@ -618,6 +618,7 @@ int xc_domid_exists(int domid);
 int xc_domid_getinfo(int domid, xc_dominfo_t *info);
 void *xc_mmap_foreign(void *addr, size_t length, int prot, int domid, xen_pfn_t *pages);
 int xc_hvm_get_dirty_vram(int domid, uint64_t base_pfn, size_t n, unsigned long *db);
+int xc_hvm_pin_memory_cacheattr(int domid, uint64_t pfn_start, uint64_t pfn_end, uint32_t type);
 /* configfile.c */
 const char *config_get(const char *prefix, const char *key);
 const char *config_dump(void);

--- a/libsurfman/src/xc.c
+++ b/libsurfman/src/xc.c
@@ -93,3 +93,8 @@ int xc_hvm_get_dirty_vram(int domid, uint64_t base_pfn, size_t n,
 {
   return xc_hvm_track_dirty_vram (xch, domid, base_pfn, n, db);
 }
+
+int xc_hvm_pin_memory_cacheattr(int domid, uint64_t pfn_start, uint64_t pfn_end, uint32_t type)
+{
+  return xc_domain_pin_memory_cacheattr(xch, domid, pfn_start, pfn_end, type);
+}

--- a/libsurfman/src/xc.c
+++ b/libsurfman/src/xc.c
@@ -54,32 +54,14 @@ int xc_domid_getinfo(int domid, xc_dominfo_t *info)
 void *xc_mmap_foreign(void *addr, size_t length, int prot,
                       int domid, xen_pfn_t *pages)
 {
-  void *ret;
-  int rc;
-  privcmd_mmapbatch_t ioctlx;
-  size_t i;
+  (void) addr; /* This is munmaped in update_mappings. */
 
-  ret = mmap (addr, length, prot, MAP_SHARED, privcmd_fd, 0);
-  if (ret == MAP_FAILED)
-    return ret;
+  assert(xch != NULL);
+  assert(length > 0);
+  assert(pages != NULL); /* It's actually an array of pfns... */
 
-  ioctlx.num = (length + XC_PAGE_SIZE - 1) / XC_PAGE_SIZE;
-  ioctlx.dom = domid;
-  ioctlx.addr = (unsigned long)ret;
-  ioctlx.arr = pages;
-
-  rc = ioctl(privcmd_fd, IOCTL_PRIVCMD_MMAPBATCH, &ioctlx);
-
-  for (i = 0; i < length; i += XC_PAGE_SIZE)
-    pages[i >> XC_PAGE_SHIFT] &= ~XEN_DOMCTL_PFINFO_LTAB_MASK;
-
-  if (rc < 0)
-    {
-      munmap(ret, length);
-      ret = MAP_FAILED;
-    }
-
-  return ret;
+  return xc_map_foreign_pages (xch, domid, prot, pages,
+                              (length + XC_PAGE_SIZE - 1 >> XC_PAGE_SHIFT));
 }
 
 int xc_translate_gpfn_to_mfn (int domid, size_t pfn_count,


### PR DESCRIPTION
- Switch to `xc_map_foreign_pages()` instead of sending the `ioctl()` on our own, libxc has compatibility support for that.
- Since auto-translated guests will send us an array of gpfn, do the translation to mfn as well. The same was done for HVM guests exposing a linear framebuffer, this only implement that function to arrays of gpfns.
- pin the cache attributes of the framebuffer pfns in the backend. The frontend should not have access to page cache attributes, and it is a requirement imposed by the backend type, not the frontend.