### PR TITLE
S9: OXT-1639: xenfb2: Amend default framebuffer values.

### DIFF
--- a/plugins/drm/src/drm-plugin.c
+++ b/plugins/drm/src/drm-plugin.c
@@ -276,7 +276,7 @@ INTERNAL surfman_psurface_t drmp_get_psurface_from_surface(surfman_plugin_t *plu
     (void) plugin;
     struct drm_surface *s;
 
-    s = malloc(sizeof (*s));
+    s = calloc(1, sizeof (*s));
     if (!s) {
         DRM_ERR("Could not allocate memory (%s).", strerror(errno));
         return NULL;
@@ -292,6 +292,7 @@ INTERNAL surfman_psurface_t drmp_get_psurface_from_surface(surfman_plugin_t *plu
     }
     s->fb.pitch = surfman_surface->stride;
     s->fb.size = surfman_surface->page_count * XC_PAGE_SIZE;
+    s->fb.offset = surfman_surface->offset;
     s->fb.map = surface_map(surfman_surface);
     s->domid = surfman_surface->pages_domid;
 

--- a/plugins/drm/src/utils.h
+++ b/plugins/drm/src/utils.h
@@ -142,7 +142,7 @@ static inline void framebuffer_dump(const char *indent, const struct framebuffer
     if (!fb) {
         DRM_DBG("%sframebuffer (%p) = { }", indent, fb);
     } else {
-        DRM_DBG("%sframebuffer (%p) = { %ux%u %u/%ubpp, %u stride, %u bytes, @%p:%lld }",
+        DRM_DBG("%sframebuffer (%p) = { %ux%u %u/%ubpp, %u stride, %u bytes, @%p:%ld }",
                 indent,
                 fb, fb->width, fb->height, fb->bpp, fb->depth, fb->pitch, fb->size,
                 fb->map, fb->offset);

--- a/surfman/src/xenfb.c
+++ b/surfman/src/xenfb.c
@@ -32,6 +32,20 @@
 
 #define XENFB_PAGE_SIZE 4096
 
+/*
+ * XenFB2 default framebuffer values.
+ * Idealy this should match the xenfb2 values to avoid unecessary resizing.
+ */
+#define XENFB2_DEFAULT_VIDEORAM (16 * 1024 * 1024)
+#define XENFB2_DEFAULT_WIDTH 1024
+#define XENFB2_DEFAULT_HEIGHT 768
+#define XENFB2_DEFAULT_BPP 32
+/* It is good practice to keep this a multiple of 64 to satisfy DRM
+ * requirements. */
+#define XENFB2_DEFAULT_PITCH \
+    (XENFB2_DEFAULT_WIDTH * XENFB2_DEFAULT_BPP / 8)
+#define XENFB2_DEFAULT_OFFSET 0
+
 static struct event backend_xenstore_event;
 
 struct xenfb_device;
@@ -257,14 +271,23 @@ xenfb_init (xen_device_t xendev)
 {
   struct xenfb_framebuffer *fb = xendev;
 
-  backend_print (fb->back, fb->devid, "default-xres", "%d", 1280);
-  backend_print (fb->back, fb->devid, "default-yres", "%d", 1024);
-  backend_print (fb->back, fb->devid, "default-bpp", "%d", 32);
-  backend_print (fb->back, fb->devid, "default-pitch", "%d", 4096);
+  backend_print (fb->back, fb->devid,
+    "default-xres", "%u", XENFB2_DEFAULT_WIDTH);
+  backend_print (fb->back, fb->devid,
+    "default-yres", "%u", XENFB2_DEFAULT_HEIGHT);
+  backend_print (fb->back, fb->devid,
+    "default-bpp", "%u", XENFB2_DEFAULT_BPP);
+  backend_print (fb->back, fb->devid,
+    "default-pitch", "%u", XENFB2_DEFAULT_PITCH);
+  backend_print (fb->back, fb->devid,
+    "videoram", "%u", XENFB2_DEFAULT_VIDEORAM);
 
-  backend_print (fb->back, fb->devid, "videoram", "%d", 16 * 1024 * 1024);
-
-  surface_update_format (fb->s, 1280, 1024, 4096, SURFMAN_FORMAT_BGRX8888, 0);
+  surface_update_format (fb->s,
+    XENFB2_DEFAULT_WIDTH,
+    XENFB2_DEFAULT_HEIGHT,
+    XENFB2_DEFAULT_PITCH,
+    SURFMAN_FORMAT_BGRX8888,
+    XENFB2_DEFAULT_OFFSET);
 
   return 0;
 }


### PR DESCRIPTION
Attend a couple of crashes related to external displays:
- libdrm release the mode list when the screen is unplugged.
- Upscaling cannot go beyond display biggest resolution.
- Error path should never assume a plugin function will succeed.
- Same for calloc.

Amend the automake definition to include header dependencies.