### PR TITLE
surfman: Only report new resolution upon change.

### DIFF
--- a/surfman/src/domain.c
+++ b/surfman/src/domain.c
@@ -100,9 +100,6 @@ domain_create (int domid)
 
   ret->domid = domid;
   LIST_INSERT_HEAD (&domain_list, ret, link);
-#if 0
-  plugin_set_guest_resolution (domid);
-#endif
   LIST_INIT (&ret->devices);
 
   return ret;

--- a/surfman/src/plugin.c
+++ b/surfman/src/plugin.c
@@ -445,19 +445,6 @@ void plugin_dpms_off (void)
     }
 }
 
-#if 0
-void
-plugin_set_guest_resolution (unsigned int domid)
-{
-  struct plugin *p;
-
-  LIST_FOREACH (p, &plugin_list, link)
-    {
-      resolution_domain_on_monitor (domid, p, p->monitors[0]);
-    }
-}
-#endif
-
 unsigned int
 plugin_stride_align (void)
 {

--- a/surfman/src/prototypes.h
+++ b/surfman/src/prototypes.h
@@ -123,7 +123,6 @@ extern unsigned int plugin_stride_align(void);
 extern int plugin_need_refresh(struct plugin *p);
 extern int plugin_display_commit(int force);
 /* resolution.c */
-extern void resolution_domain_on_monitor(unsigned int domid, struct plugin *plugin, surfman_monitor_t monitor);
 extern void resolution_refresh_current(struct plugin *plugin);
 extern void resolution_init(void);
 /* xenfb.c */

--- a/surfman/src/resolution.c
+++ b/surfman/src/resolution.c
@@ -27,10 +27,16 @@ static void
 set_current_display_size(unsigned int x, unsigned int y)
 {
     char buf[256];
+    static unsigned int cx = 0, cy = 0;
+
+    if ((cx == x) && (cy == y))
+        return;
 
     snprintf(buf, 256, "%d %d", x, y);
-    /* surfman_info ("setting %s to %s\n", current_display_size_path, buf); */
-    xenstore_write (buf, current_display_size_path, buf);
+    surfman_info("setting %s to %s\n", current_display_size_path, buf);
+    xenstore_write(buf, current_display_size_path, buf);
+    cx = x;
+    cy = y;
 }
 
 /* XXX: This will have to go */
@@ -102,25 +108,6 @@ static void resolution_xs_read(unsigned int domid, unsigned int *w, unsigned int
             *h = internal_h;
         }
         free(tmp);
-    }
-}
-
-void 
-resolution_domain_on_monitor(unsigned int domid, struct plugin *plugin, surfman_monitor_t monitor)
-{
-    unsigned int w = 0, h = 0;
-    unsigned int xs_w = 0, xs_h = 0;
-    char buf[256];
-
-    if (!get_resolution_from_monitor(plugin, monitor, &w, &h))
-        return;
-    resolution_xs_read(domid, &xs_w, &xs_h);
-    if (xs_w != w || xs_h != h)
-    {
-        snprintf(buf, 256, "%d %d", w, h);
-        surfman_info ("setting /local/domain/%d/%s to %s\n", domid, display_size_path, buf);
-        xenstore_dom_write (domid, buf, display_size_path);
-        set_current_display_size(w, h);
     }
 }
 


### PR DESCRIPTION
Surfman reports the current recommended resolution for guests through
Xenstore after its plugin returned it. The set_current_display_size()
function is doing the XenStore write, but it is called in different
context without checking if the change is meaningful.

Surfman ends up constantly writing the XenStore entry, which trips all
watches on that key. Avoid that by making set_current_display_size()
check against the last written value.

Also call set_current_display_size at all relevant call-sites and remove
dead-code associated with that logic.